### PR TITLE
Handle non utf 8 bytes in patch files.

### DIFF
--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2017-2020, SUSE LLC
+# Copyright (c) 2017-2022, SUSE LLC
 #
 # All rights reserved.
 #
@@ -30,7 +30,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-'''
+"""
  Author: Bo Maryniuk <bo@suse.de>
 
   This tool helps to:
@@ -42,7 +42,7 @@
   3. Detect content differences, if the filename is still the same
 
   4. Generate include message for .changes logfile
-'''
+"""
 
 import os
 import sys
@@ -51,21 +51,22 @@ import argparse
 import shutil
 
 
-ORDERING_FILE = 'patches.orders.txt'
-CHANGES_FILE = 'patches.changes.txt'
+ORDERING_FILE = "patches.orders.txt"
+CHANGES_FILE = "patches.changes.txt"
 
 
 def remove_order(filename):
-    '''
+    """
     Remove order of the patch filename.
 
     Git formats patches: XXXX-filename.patch
     This function removes the "XXXX-" part, if any.
-    '''
-    ordnum = os.path.basename(filename).split('-')[0]
-    if ordnum and not re.sub(r'[0-9]', '', ordnum):
-        filename = os.path.join(os.path.dirname(filename),
-                                filename.split('-', 1)[-1]).lower()
+    """
+    ordnum = os.path.basename(filename).split("-")[0]
+    if ordnum and not re.sub(r"[0-9]", "", ordnum):
+        filename = os.path.join(
+            os.path.dirname(filename), filename.split("-", 1)[-1]
+        ).lower()
         ordnum = int(ordnum)
     else:
         ordnum = None
@@ -74,7 +75,7 @@ def remove_order(filename):
 
 
 def remove_order_from_subject(src_file, dst_file, use_unique=False):
-    '''
+    """
     Remove subject inside the patch.
 
     Git format patches inside with the following subject format:
@@ -83,92 +84,93 @@ def remove_order_from_subject(src_file, dst_file, use_unique=False):
     This function removes [PATCH X/Y] part, if any. In Git
     format-patches one can add "-N" flag, so then subject won't have
     these numbers, but just "[PATCH]". In this case we leave it out.
-    '''
+    """
 
     if os.path.exists(dst_file) and not use_unique:
-        raise IOError('the file {0} exists'.format(dst_file))
+        raise IOError("the file {0} exists".format(dst_file))
 
     if os.path.exists(dst_file) and use_unique:
         dst_file = unique(dst_file)
-    dst = open(dst_file, 'w')
+    dst = open(dst_file, "w")
     for fline in open(src_file).read().split(os.linesep):
-        fline_tk = re.split(r'\s+\[PATCH \d+/\d+\]\s+', fline)
-        if len(fline_tk) == 2 and fline_tk[0] == 'Subject:':
-            fline = ' [PATCH] '.join(fline_tk)
-        dst.write('{0}\n'.format(fline))
+        fline_tk = re.split(r"\s+\[PATCH \d+/\d+\]\s+", fline)
+        if len(fline_tk) == 2 and fline_tk[0] == "Subject:":
+            fline = " [PATCH] ".join(fline_tk)
+        dst.write("{0}\n".format(fline))
     dst.close()
 
 
 def git_format_patch(tag):
-    '''
+    """
     Formats patches from the given tag.
-    '''
+    """
     patches = 0
-    for patch in os.popen(
-            'git format-patch {0}'.format(tag)).read().split(os.linesep):
-        if patch.split('.')[-1] == 'patch':
+    for patch in os.popen("git format-patch {0}".format(tag)).read().split(os.linesep):
+        if patch.split(".")[-1] == "patch":
             patches += 1
 
     print("Patches fetched: {0}".format(patches))
 
 
 def get_diff_contents(data):
-    '''
+    """
     Get diff contents only.
-    '''
+    """
     # Yes, I know about library https://github.com/cscorley/whatthepatch
     # But for now we go ultra-primitive to keep no deps
-    data = '--'.join(data.split("--")[:-1])
+    data = "--".join(data.split("--")[:-1])
     contents = []
-    for chunk in re.split(r'@@.*?@@.*?\n', data)[1:]:
-        contents.append(chunk.split('diff --git')[0])
+    for chunk in re.split(r"@@.*?@@.*?\n", data)[1:]:
+        contents.append(chunk.split("diff --git")[0])
 
     return contents
 
 
 def unique(fname):
-    '''
+    """
     Change name to the unique, in case it isn't.
 
     :param fname:
     :param use:
     :return:
-    '''
-    fname = fname.split('.')
-    if '-' not in fname[0]:
-        fname[0] = '{0}-{1}'.format(fname[0], 1)
+    """
+    fname = fname.split(".")
+    if "-" not in fname[0]:
+        fname[0] = "{0}-{1}".format(fname[0], 1)
     else:
-        chnk = fname[0].split('-')
+        chnk = fname[0].split("-")
         try:
-            fname[0] = '{0}-{1}'.format('-'.join(chnk[:-1]), int(chnk[-1]) + 1)
+            fname[0] = "{0}-{1}".format("-".join(chnk[:-1]), int(chnk[-1]) + 1)
         except ValueError:
             # Filename is not in "str-int", but "str-str".
-            fname[0] = '{0}-{1}'.format(fname[0], 1)
+            fname[0] = "{0}-{1}".format(fname[0], 1)
 
-    return '.'.join(fname)
+    return ".".join(fname)
 
 
 def extract_spec_source_patches(specfile):
-    '''
+    """
     Extracts source patches from the .spec file to match existing
     comments, according to the
     https://en.opensuse.org/openSUSE:Packaging_Patches_guidelines
 
     :param: specfile
     :return:
-    '''
+    """
     patch_sec_start = False
     patch_sec_end = False
     head_buff = []
     patch_section = []
     for spec_line in open(specfile).read().split(os.linesep):
-        if re.match(r'^[Pp]atch[0-9]+:', spec_line) and not patch_sec_start:
+        if re.match(r"^[Pp]atch[0-9]+:", spec_line) and not patch_sec_start:
             patch_sec_start = True
 
-        if not spec_line.startswith('#') and \
-                not re.match(r'^[Pp]atch[0-9]+:', spec_line) and \
-                patch_sec_start and \
-                not patch_sec_end:
+        if (
+            not spec_line.startswith("#")
+            and not re.match(r"^[Pp]atch[0-9]+:", spec_line)
+            and patch_sec_start
+            and not patch_sec_end
+        ):
             patch_sec_end = True
 
         if not patch_sec_start and not patch_sec_end:
@@ -181,50 +183,56 @@ def extract_spec_source_patches(specfile):
     for head_line in reversed(head_buff):
         if not head_line:
             break
-        if head_line.startswith('#'):
+        if head_line.startswith("#"):
             first_comment.append(head_line)
     patch_section.insert(0, os.linesep.join(first_comment))
 
     patchset = {}
     curr_key = None
     for line in reversed(patch_section):
-        if re.match(r'^[Pp]atch[0-9]+:', line):
-            curr_key = re.sub(r'^[Pp]atch[0-9]+:', '', line).strip()
+        if re.match(r"^[Pp]atch[0-9]+:", line):
+            curr_key = re.sub(r"^[Pp]atch[0-9]+:", "", line).strip()
             patchset[curr_key] = []
             continue
-        if curr_key and line and line.startswith('#'):
+        if curr_key and line and line.startswith("#"):
             patchset[curr_key].append(line)
 
     return patchset
 
 
 def do_remix_spec(args):
-    '''
+    """
     Remix spec file.
 
     :param args:
     :return:
-    '''
-    if not os.path.exists(args.spec or ''):
-        raise IOError('Specfile {0} is not accessible or is somewhere else'.format(args.spec))
-    if not os.path.exists(args.ordering or ''):
-        args.ordering = './{0}'.format(ORDERING_FILE)
+    """
+    if not os.path.exists(args.spec or ""):
+        raise IOError(
+            "Specfile {0} is not accessible or is somewhere else".format(args.spec)
+        )
+    if not os.path.exists(args.ordering or ""):
+        args.ordering = "./{0}".format(ORDERING_FILE)
         if not os.path.exists(args.ordering):
-            raise IOError('Ordering file is expected "./{0}" but is not visible'.format(ORDERING_FILE))
+            raise IOError(
+                'Ordering file is expected "./{0}" but is not visible'.format(
+                    ORDERING_FILE
+                )
+            )
 
     patchset = extract_spec_source_patches(args.spec)
     for o_line in open(args.ordering).read().split(os.linesep):
-        if re.match(r'^[Pp]atch[0-9]+:', o_line):
-            ref, pname = [_f for _f in o_line.split(' ') if _f]
-            print(os.linesep.join(patchset.get(pname) or ['# Description N/A']))
+        if re.match(r"^[Pp]atch[0-9]+:", o_line):
+            ref, pname = [_f for _f in o_line.split(" ") if _f]
+            print(os.linesep.join(patchset.get(pname) or ["# Description N/A"]))
             print(ref.ljust(15), pname)
 
 
 def do_create_patches(args):
-    '''
+    """
     Create and reformat patches for the package.
-    '''
-    current_dir = os.path.abspath('.')
+    """
+    current_dir = os.path.abspath(".")
 
     if not args.existing:
         if os.listdir(current_dir):
@@ -233,20 +241,29 @@ def do_create_patches(args):
 
         git_format_patch(args.format)
     else:
-        if not [fname for fname in os.listdir(current_dir) if fname.endswith('.patch')]:
-            print("Error: can't find a single patch in {0} to work with!".format(current_dir))
+        if not [fname for fname in os.listdir(current_dir) if fname.endswith(".patch")]:
+            print(
+                "Error: can't find a single patch in {0} to work with!".format(
+                    current_dir
+                )
+            )
             sys.exit(1)
 
-    ord_fh = open(args.ordering or ORDERING_FILE, 'w')
-    ord_fh.write('#\n#\n# This is pre-generated snippets of patch ordering\n#\n')
+    ord_fh = open(args.ordering or ORDERING_FILE, "w")
+    ord_fh.write("#\n#\n# This is pre-generated snippets of patch ordering\n#\n")
     ord_patches_p = []
 
     patches = 0
     for fname in os.listdir(current_dir):
-        if fname.split('.')[-1] == 'patch':
+        if fname.split(".")[-1] == "patch":
             # Check if we should skip this patch in case subject starts with SKIP_TAG
             with open(fname) as patch_file:
-                if any(re.match(r'^Subject: \[PATCH.*] {}'.format(re.escape(args.skip_tag)), i) for i in patch_file.readlines()):
+                if any(
+                    re.match(
+                        r"^Subject: \[PATCH.*] {}".format(re.escape(args.skip_tag)), i
+                    )
+                    for i in patch_file.readlines()
+                ):
                     print("Skipping {}".format(fname))
                     os.unlink(fname)
                     continue
@@ -257,27 +274,31 @@ def do_create_patches(args):
                 order += args.index
             remove_order_from_subject(fname, nfname, use_unique=args.increment)
             os.unlink(fname)
-            ord_fh.write('{patch}{fname}\n'.format(patch='Patch{0}:'.format(order).ljust(15), fname=nfname))
+            ord_fh.write(
+                "{patch}{fname}\n".format(
+                    patch="Patch{0}:".format(order).ljust(15), fname=nfname
+                )
+            )
             ord_patches_p.append(order)
 
             patches += 1
 
     if ord_patches_p:
-        ord_fh.write('#\n#\n# Patch processing inclusion:\n')
+        ord_fh.write("#\n#\n# Patch processing inclusion:\n")
         for order in ord_patches_p:
-            ord_fh.write('%patch{num} -p1\n'.format(num=order))
+            ord_fh.write("%patch{num} -p1\n".format(num=order))
     else:
-        ord_fh.write('# Nothing here, folks... :-(\n')
+        ord_fh.write("# Nothing here, folks... :-(\n")
 
     ord_fh.close()
 
-    print("\nRe-formatted {0} patch{1}".format(patches, patches > 1 and 'es' or ''))
+    print("\nRe-formatted {0} patch{1}".format(patches, patches > 1 and "es" or ""))
 
 
 def do_update_patches(args):
-    '''
+    """
     Update patches on the target package source.
-    '''
+    """
     print("Updating packages from {0} directory".format(args.update))
     added = []
     removed = []
@@ -286,11 +307,11 @@ def do_update_patches(args):
     # Gather current patches
     current_patches = {}
     for fname in os.listdir(os.path.abspath(".")):
-        if fname.endswith('.patch'):
+        if fname.endswith(".patch"):
             current_patches[os.path.basename(fname)] = True
 
     for fname in os.listdir(args.update):
-        if fname.endswith('.patch'):
+        if fname.endswith(".patch"):
             fname = os.path.join(args.update, fname)
             if os.path.isfile(fname):
                 current_patches[os.path.basename(fname)] = False
@@ -300,24 +321,37 @@ def do_update_patches(args):
                     shutil.copyfile(fname, os.path.join(os.path.abspath("."), n_fname))
                     added.append(n_fname)
                 else:
-                    if get_diff_contents(open(fname).read()) != get_diff_contents(open(n_fname).read()):
+                    if get_diff_contents(open(fname).read()) != get_diff_contents(
+                        open(n_fname).read()
+                    ):
                         if args.changed:
                             print("Replacing {0} patch".format(n_fname))
                             os.unlink(n_fname)
-                            shutil.copyfile(fname, os.path.join(os.path.abspath("."), n_fname))
+                            shutil.copyfile(
+                                fname, os.path.join(os.path.abspath("."), n_fname)
+                            )
                             changed.append(n_fname)
                         else:
-                            print("WARNING: Patches {0} and {1} are different!".format(fname, n_fname))
+                            print(
+                                "WARNING: Patches {0} and {1} are different!".format(
+                                    fname, n_fname
+                                )
+                            )
 
-    for fname in sorted([patch_name for patch_name, is_dead in list(current_patches.items()) if is_dead]):
+    for fname in sorted(
+        [patch_name for patch_name, is_dead in list(current_patches.items()) if is_dead]
+    ):
         print("Removing {0} patch".format(fname))
         os.unlink(fname)
         removed.append(fname)
 
     # Generate an include for spec changes
     with open(CHANGES_FILE, "w") as changes:
-        for title, data in [('Changed', changed), ('Added', added),
-                            ('Removed', removed)]:
+        for title, data in [
+            ("Changed", changed),
+            ("Added", added),
+            ("Removed", removed),
+        ]:
             if not data:
                 continue
             print("- {}:".format(title), file=changes)
@@ -330,31 +364,78 @@ def do_update_patches(args):
 
 
 def main():
-    '''
+    """
     Main app.
-    '''
-    VERSION = '0.2'
-    parser = argparse.ArgumentParser(description='Git patch formatter for RPM packages')
-    parser.add_argument('-u', '--update', action='store', const=None,
-                        help='update current patches with the destination path')
-    parser.add_argument('-f', '--format', action='store', const=None,
-                        help='specify tag or range of commits for patches to be formatted')
-    parser.add_argument('-o', '--ordering', action='store', const=None,
-                        help='specify ordering spec inclusion file. Default: {0}'.format(ORDERING_FILE))
-    parser.add_argument('-x', '--index', action='store', const=None,
-                        help='specify start ordering index. Default: 0')
-    parser.add_argument('-s', '--spec', action='store', const=None,
-                        help='remix spec file and extract sources with their comments to match new patch ordering')
-    parser.add_argument('-i', '--increment', action='store_const', const=True,
-                        help='use increments for unique names when patch commits repeated')
-    parser.add_argument('-c', '--changed', action='store_const', const=True,
-                        help='update also changed files with the content')
-    parser.add_argument('-e', '--existing', action='store_const', const=True,
-                        help='work with already formatted patches from Git')
-    parser.add_argument('-k', '--skip-tag', action='store', const=None, default='[skip]',
-                        help='skip commits starting with this tag. Default: [skip]')
-    parser.add_argument('-v', '--version', action='store_const', const=True,
-                        help='show version')
+    """
+    VERSION = "0.2"
+    parser = argparse.ArgumentParser(description="Git patch formatter for RPM packages")
+    parser.add_argument(
+        "-u",
+        "--update",
+        action="store",
+        const=None,
+        help="update current patches with the destination path",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        action="store",
+        const=None,
+        help="specify tag or range of commits for patches to be formatted",
+    )
+    parser.add_argument(
+        "-o",
+        "--ordering",
+        action="store",
+        const=None,
+        help="specify ordering spec inclusion file. Default: {0}".format(ORDERING_FILE),
+    )
+    parser.add_argument(
+        "-x",
+        "--index",
+        action="store",
+        const=None,
+        help="specify start ordering index. Default: 0",
+    )
+    parser.add_argument(
+        "-s",
+        "--spec",
+        action="store",
+        const=None,
+        help="remix spec file and extract sources with their comments to match new patch ordering",
+    )
+    parser.add_argument(
+        "-i",
+        "--increment",
+        action="store_const",
+        const=True,
+        help="use increments for unique names when patch commits repeated",
+    )
+    parser.add_argument(
+        "-c",
+        "--changed",
+        action="store_const",
+        const=True,
+        help="update also changed files with the content",
+    )
+    parser.add_argument(
+        "-e",
+        "--existing",
+        action="store_const",
+        const=True,
+        help="work with already formatted patches from Git",
+    )
+    parser.add_argument(
+        "-k",
+        "--skip-tag",
+        action="store",
+        const=None,
+        default="[skip]",
+        help="skip commits starting with this tag. Default: [skip]",
+    )
+    parser.add_argument(
+        "-v", "--version", action="store_const", const=True, help="show version"
+    )
     args = parser.parse_args()
 
     try:
@@ -379,5 +460,5 @@ def main():
         print("Critical error:", ex, file=sys.stderr)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -91,13 +91,14 @@ def remove_order_from_subject(src_file, dst_file, use_unique=False):
 
     if os.path.exists(dst_file) and use_unique:
         dst_file = unique(dst_file)
-    dst = open(dst_file, "w")
-    for fline in open(src_file).read().split(os.linesep):
-        fline_tk = re.split(r"\s+\[PATCH \d+/\d+\]\s+", fline)
-        if len(fline_tk) == 2 and fline_tk[0] == "Subject:":
-            fline = " [PATCH] ".join(fline_tk)
-        dst.write("{0}\n".format(fline))
-    dst.close()
+    with open(dst_file, "w", encoding="utf-8", errors="surrogateescape") as dst, open(
+        src_file, encoding="utf-8", errors="surrogateescape"
+    ) as src:
+        for line in src:
+            line_tk = re.split(r"\s+\[PATCH \d+/\d+\]\s+", line)
+            if len(line_tk) == 2 and line_tk[0] == "Subject:":
+                line = " [PATCH] ".join(line_tk)
+            dst.write("{0}".format(line))
 
 
 def git_format_patch(tag):
@@ -257,7 +258,7 @@ def do_create_patches(args):
     for fname in os.listdir(current_dir):
         if fname.split(".")[-1] == "patch":
             # Check if we should skip this patch in case subject starts with SKIP_TAG
-            with open(fname) as patch_file:
+            with open(fname, encoding="utf-8", errors="surrogatereplace") as patch_file:
                 if any(
                     re.match(
                         r"^Subject: \[PATCH.*] {}".format(re.escape(args.skip_tag)), i
@@ -321,22 +322,27 @@ def do_update_patches(args):
                     shutil.copyfile(fname, os.path.join(os.path.abspath("."), n_fname))
                     added.append(n_fname)
                 else:
-                    if get_diff_contents(open(fname).read()) != get_diff_contents(
-                        open(n_fname).read()
-                    ):
-                        if args.changed:
-                            print("Replacing {0} patch".format(n_fname))
-                            os.unlink(n_fname)
-                            shutil.copyfile(
-                                fname, os.path.join(os.path.abspath("."), n_fname)
-                            )
-                            changed.append(n_fname)
-                        else:
-                            print(
-                                "WARNING: Patches {0} and {1} are different!".format(
-                                    fname, n_fname
+                    with open(
+                        fname, encoding="utf-8", errors="surrogateescape"
+                    ) as updated_patch, open(
+                        n_fname, encoding="utf-8", errors="surrogateescape"
+                    ) as existing_patch:
+                        if get_diff_contents(updated_patch.read()) != get_diff_contents(
+                            existing_patch.read()
+                        ):
+                            if args.changed:
+                                print("Replacing {0} patch".format(n_fname))
+                                os.unlink(n_fname)
+                                shutil.copyfile(
+                                    fname, os.path.join(os.path.abspath("."), n_fname)
                                 )
-                            )
+                                changed.append(n_fname)
+                            else:
+                                print(
+                                    "WARNING: Patches {0} and {1} are different!".format(
+                                        fname, n_fname
+                                    )
+                                )
 
     for fname in sorted(
         [patch_name for patch_name, is_dead in list(current_patches.items()) if is_dead]


### PR DESCRIPTION
The interesting commit is "Handle non-utf-8 bytes in patches", but I included a reformatting commit before. `black` is pretty stable, I don't think it did any harm.

The approach I took was to "surrogateescape" non-UTF-8 bytes. When the patch files are opened to search for the skip tag, non-UTF-8 bytes aren't interesting since the skip tag is valid UTF-8 in almost all
cases. The other situation is manually copying the patch files on `--update`, here it's required to not mess with non-UTF-8 bytes inside the patches.