### PR TITLE
Add black GH Action

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,0 +1,14 @@
+name: Code style
+
+on:
+  push:
+    branches: ["master"]
+pull_request:
+    branches: [ master ]
+
+jobs:
+  code_style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable


### PR DESCRIPTION
Let's make sure we keep the code formatted with black. This Action only runs the validation, we still need to run it locally to make sure our commits are formatted correctly.