### PR TITLE
Fix code_style workflow syntax

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -3,8 +3,8 @@ name: Code style
 on:
   push:
     branches: ["master"]
-pull_request:
-    branches: [ master ]
+  pull_request:
+    branches: ["master"]
 
 jobs:
   code_style:


### PR DESCRIPTION
We got a failure because I messed the syntax up: https://github.com/openSUSE/git-packaging-tools/actions/runs/3233719759