### PR TITLE
Add debian support (partially)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ dirname="git-packaging-tools-$(get_version)"
 cleanup $dirname
 mkdir $dirname
 cp git-format-pkg-patch $dirname
+cp doc/*.1 $dirname
 tar cvf - $dirname | gzip -9 > $(get_archive_name)
 rm -rf $dirname
 echo "Done"

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -265,8 +265,10 @@ def do_create_patches(args):
             sys.exit(1)
 
     ord_fh: TextIOWrapper = open(args.ordering or ORDERING_FILE, "w")
-    ord_fh.write("#\n#\n# This is pre-generated snippets of patch ordering\n#\n")
     ord_patches_p: OrderedDict[int, str] = OrderedDict()
+
+    if IS_RPM:
+        ord_fh.write("#\n#\n# This is pre-generated snippets of patch ordering\n#\n")
 
     patches = 0
     for fname in os.listdir(current_dir):
@@ -289,11 +291,12 @@ def do_create_patches(args):
                 order += args.index
             remove_order_from_subject(fname, nfname, use_unique=args.increment)
             os.unlink(fname)
-            ord_fh.write(
-                "{patch}{fname}\n".format(
-                    patch=f"Patch{order}:".ljust(15), fname=nfname
+            if IS_RPM:
+                ord_fh.write(
+                    "{patch}{fname}\n".format(
+                        patch=f"Patch{order}:".ljust(15), fname=nfname
+                    )
                 )
-            )
             ord_patches_p[order] = fname
 
             patches += 1

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -84,7 +84,7 @@ def remove_order(filename):
     return ordnum, filename
 
 
-def remove_order_from_subject(src_file, dst_file, use_unique=False):
+def remove_order_from_subject(src_file, dst_file, use_unique=False) -> str:
     """
     Remove subject inside the patch.
 
@@ -94,6 +94,8 @@ def remove_order_from_subject(src_file, dst_file, use_unique=False):
     This function removes [PATCH X/Y] part, if any. In Git
     format-patches one can add "-N" flag, so then subject won't have
     these numbers, but just "[PATCH]". In this case we leave it out.
+
+    Returns final written filename.
     """
 
     if os.path.exists(dst_file) and not use_unique:
@@ -109,6 +111,8 @@ def remove_order_from_subject(src_file, dst_file, use_unique=False):
             if len(line_tk) == 2 and line_tk[0] == "Subject:":
                 line = " [PATCH] ".join(line_tk)
             dst.write("{0}".format(line))
+
+    return dst_file
 
 
 def git_format_patch(tag):

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -44,6 +44,7 @@
   4. Generate include message for .changes logfile
 """
 
+from io import TextIOWrapper
 import os
 import sys
 import re
@@ -259,7 +260,7 @@ def do_create_patches(args):
             )
             sys.exit(1)
 
-    ord_fh = open(args.ordering or ORDERING_FILE, "w")
+    ord_fh: TextIOWrapper = open(args.ordering or ORDERING_FILE, "w")
     ord_fh.write("#\n#\n# This is pre-generated snippets of patch ordering\n#\n")
     ord_patches_p: OrderedDict[int, str] = OrderedDict()
 

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -304,7 +304,7 @@ def do_create_patches(args):
             if IS_RPM:
                 ord_fh.write(f"%patch{order} -p1\n")
             else:
-                ord_fh.write(f"{fname} -p1")
+                ord_fh.write(f"{fname} -p1\n")
     else:
         ord_fh.write("# No patches found\n")
     ord_fh.close()

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -289,7 +289,7 @@ def do_create_patches(args):
             order, nfname = remove_order(fname)
             if args.index is not None:
                 order += args.index
-            remove_order_from_subject(fname, nfname, use_unique=args.increment)
+            nfname = remove_order_from_subject(fname, nfname, use_unique=args.increment)
             os.unlink(fname)
             if IS_RPM:
                 ord_fh.write(
@@ -297,7 +297,7 @@ def do_create_patches(args):
                         patch=f"Patch{order}:".ljust(15), fname=nfname
                     )
                 )
-            ord_patches_p[order] = fname
+            ord_patches_p[order] = nfname
 
             patches += 1
 

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -394,7 +394,7 @@ def main():
     """
     Main app.
     """
-    VERSION = "0.2"
+    VERSION = "0.3"
     parser = argparse.ArgumentParser(description="Git patch formatter for RPM packages")
     parser.add_argument(
         "-u",

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -274,11 +274,11 @@ def do_create_patches(args):
                     )
                     for i in patch_file.readlines()
                 ):
-                    print("Skipping {}".format(fname))
+                    print(f"Skipping {fname}")
                     os.unlink(fname)
                     continue
 
-            print("Preparing {}".format(fname))
+            print(f"Preparing {fname}")
             order, nfname = remove_order(fname)
             if args.index is not None:
                 order += args.index
@@ -286,10 +286,10 @@ def do_create_patches(args):
             os.unlink(fname)
             ord_fh.write(
                 "{patch}{fname}\n".format(
-                    patch="Patch{0}:".format(order).ljust(15), fname=nfname
+                    patch=f"Patch{order}:".ljust(15), fname=nfname
                 )
             )
-            ord_patches_p.append(order)
+            ord_patches_p[order] = fname
 
             patches += 1
 
@@ -308,14 +308,14 @@ def do_create_patches(args):
         ord_fh.write("# No patches found\n")
     ord_fh.close()
 
-    print("\nRe-formatted {0} patch{1}".format(patches, patches > 1 and "es" or ""))
+    print(f"\nRe-formatted {patches} patch{patches > 1 and 'es' or ''}")
 
 
 def do_update_patches(args):
     """
     Update patches on the target package source.
     """
-    print("Updating packages from {0} directory".format(args.update))
+    print(f"Updating packages from {args.update} directory")
     added = []
     removed = []
     changed = []
@@ -333,7 +333,7 @@ def do_update_patches(args):
                 current_patches[os.path.basename(fname)] = False
                 n_fname = os.path.basename(fname)
                 if not os.path.exists(n_fname):
-                    print("Adding {0} patch".format(fname))
+                    print(f"Adding {fname} patch")
                     shutil.copyfile(fname, os.path.join(os.path.abspath("."), n_fname))
                     added.append(n_fname)
                 else:
@@ -346,7 +346,7 @@ def do_update_patches(args):
                             existing_patch.read()
                         ):
                             if args.changed:
-                                print("Replacing {0} patch".format(n_fname))
+                                print(f"Replacing {n_fname} patch")
                                 os.unlink(n_fname)
                                 shutil.copyfile(
                                     fname, os.path.join(os.path.abspath("."), n_fname)
@@ -354,15 +354,13 @@ def do_update_patches(args):
                                 changed.append(n_fname)
                             else:
                                 print(
-                                    "WARNING: Patches {0} and {1} are different!".format(
-                                        fname, n_fname
-                                    )
+                                    f"WARNING: Patches {fname} and {n_fname} are different!"
                                 )
 
     for fname in sorted(
         [patch_name for patch_name, is_dead in list(current_patches.items()) if is_dead]
     ):
-        print("Removing {0} patch".format(fname))
+        print(f"Removing {fname} patch")
         os.unlink(fname)
         removed.append(fname)
 
@@ -375,9 +373,9 @@ def do_update_patches(args):
         ]:
             if not data:
                 continue
-            print("- {}:".format(title), file=changes)
+            print(f"- {title}:", file=changes)
             for fname in sorted(data):
-                print("  * {}".format(fname), file=changes)
+                print(f"  * {fname}", file=changes)
             print(file=changes)
 
         if not removed and not added and not changes:

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -50,6 +50,7 @@ import re
 import argparse
 import shutil
 import distro
+from collections import OrderedDict
 from typing import Any
 
 
@@ -260,7 +261,7 @@ def do_create_patches(args):
 
     ord_fh = open(args.ordering or ORDERING_FILE, "w")
     ord_fh.write("#\n#\n# This is pre-generated snippets of patch ordering\n#\n")
-    ord_patches_p = []
+    ord_patches_p: OrderedDict[int, str] = OrderedDict()
 
     patches = 0
     for fname in os.listdir(current_dir):
@@ -293,12 +294,18 @@ def do_create_patches(args):
             patches += 1
 
     if ord_patches_p:
-        ord_fh.write("#\n#\n# Patch processing inclusion:\n")
-        for order in ord_patches_p:
-            ord_fh.write("%patch{num} -p1\n".format(num=order))
-    else:
-        ord_fh.write("# Nothing here, folks... :-(\n")
+        if IS_RPM:
+            ord_fh.write("#\n#\n# List of available patches:\n")
+        else:
+            ord_fh.write("#\n#\n# debian/series:\n")
 
+        for order, fname in ord_patches_p.items():
+            if IS_RPM:
+                ord_fh.write(f"%patch{order} -p1\n")
+            else:
+                ord_fh.write(f"{fname} -p1")
+    else:
+        ord_fh.write("# No patches found\n")
     ord_fh.close()
 
     print("\nRe-formatted {0} patch{1}".format(patches, patches > 1 and "es" or ""))

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -50,6 +50,7 @@ import re
 import argparse
 import shutil
 import distro
+from typing import Any
 
 
 ORDERING_FILE = "patches.orders.txt"
@@ -195,7 +196,7 @@ def extract_spec_source_patches(specfile):
             first_comment.append(head_line)
     patch_section.insert(0, os.linesep.join(first_comment))
 
-    patchset = {}
+    patchset: dict[str, list[Any]] = {}
     curr_key = None
     for line in reversed(patch_section):
         if re.match(r"^[Pp]atch[0-9]+:", line):

--- a/git-format-pkg-patch
+++ b/git-format-pkg-patch
@@ -49,10 +49,17 @@ import sys
 import re
 import argparse
 import shutil
+import distro
 
 
 ORDERING_FILE = "patches.orders.txt"
 CHANGES_FILE = "patches.changes.txt"
+
+# Simplest detection if we are on Leap/SLES/RHEL or debian family. Add more IDs on demand.
+IS_DEB: bool = distro.id() in ["ubuntu", "debian", "linuxmint"] and bool(
+    shutil.which("dpkg")
+)
+IS_RPM: bool = not IS_DEB and bool(shutil.which("rpm"))
 
 
 def remove_order(filename):


### PR DESCRIPTION
After almost 7 years of pause 😆 I am back to this tool! This PR adds the following:
- Detects if it is on Debian/Ubuntu or not
  _NOTE: dependency on `python3-distro` packaging required, but it is a standard one in both RPM and Debian worlds_
- Writes either patchlist for `.spec` or `debian/series`.
- Partially removes `.format()` for at least `print` statements.
- Removes few minor MyPy errors

When packaging this version, please add `Requires: python3-distro`.